### PR TITLE
limit ast ability to see properties and guests.

### DIFF
--- a/backend/src/controller/houses.ts
+++ b/backend/src/controller/houses.ts
@@ -57,7 +57,6 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
   try {
     const { id } = req.params;
     let house: any;
-    let ids;
     if (id) {
       house = await findHouse(id);
     } else {
@@ -65,13 +64,11 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
       if (req.token.role === 'assistant') {
         const ast = await getRoleId(req.token.id, true);
         const astMan = await findAstMan(ast.id);
-        ids = astMan;
+        house = await findHouses(astMan, req.token.id);
       } else {
         const manager = await getRoleId(req.token.id);
-        ids = [manager.id];
+        house = await findHouses([manager.id]);
       }
-
-      house = await findHouses(ids);
     }
     if (house === undefined) {
       throw Error('no user');

--- a/backend/src/controller/stays.ts
+++ b/backend/src/controller/stays.ts
@@ -63,11 +63,12 @@ export async function getAll(
     // const stays = await findAllStays(String(extit), filter);
     let stays: any;
     if (role === 'assistant') {
+      // if user is an assistant, we find ast_id, find all asigned managers
       const ast = await getRoleId(id, true);
       const astMan = await findAstMan(ast.id);
       stays = await findAllStays(astMan, filter, id);
     } else {
-      const manager = await getRoleId(req.token.id);
+      const manager = await getRoleId(id);
       stays = await findAllStays([manager.id], filter);
     }
     res.status(200).json(stays);

--- a/backend/src/controller/stays.ts
+++ b/backend/src/controller/stays.ts
@@ -62,16 +62,14 @@ export async function getAll(
     const { id, role } = req.token;
     // const stays = await findAllStays(String(extit), filter);
     let stays: any;
-    let ids;
     if (role === 'assistant') {
       const ast = await getRoleId(id, true);
       const astMan = await findAstMan(ast.id);
-      ids = astMan;
+      stays = await findAllStays(astMan, filter, id);
     } else {
       const manager = await getRoleId(req.token.id);
-      ids = [manager.id];
+      stays = await findAllStays([manager.id], filter);
     }
-    stays = await findAllStays(ids, filter);
     res.status(200).json(stays);
   } catch (e) {
     e.statusCode = e.statusCode || 400;

--- a/backend/src/models/houses.ts
+++ b/backend/src/models/houses.ts
@@ -18,6 +18,8 @@ export const findHouses = (manager: number[], astId?: number) => {
       'house.photo_url',
     )
     .whereIn('house.manager', manager);
+  // if getting houses for an ast, we want to only show houses
+  // where the ast is linked on house_ast table
   if (astId) {
     query
       .leftJoin('house_ast', { 'house.id': 'house_ast.house_id' })

--- a/backend/src/models/houses.ts
+++ b/backend/src/models/houses.ts
@@ -2,8 +2,8 @@ import { QueryBuilder } from 'knex';
 import db from '../../data/dbConfig';
 import { House } from '../interface';
 
-export const findHouses = (manager: number[]) => {
-  return db('house')
+export const findHouses = (manager: number[], astId?: number) => {
+  const query: QueryBuilder = db('house')
     .leftJoin('assistant', { 'house.default_ast': 'assistant.id' })
     .leftJoin('user', { 'assistant.user_id': 'user.id' })
     .select(
@@ -17,23 +17,25 @@ export const findHouses = (manager: number[]) => {
       'house.ast_guide',
       'house.photo_url',
     )
-    .whereIn('house.manager', manager)
-    .map(async (e: any) => {
-      const openAst = await db('house_ast')
-        .where({ 'house_ast.house_id': e.id })
-        .leftJoin('assistant', { 'house_ast.ast_id': 'assistant.id' })
-        .leftJoin('user', { 'assistant.user_id': 'user.id' })
-        .select(
-          'user.full_name',
-          'assistant.id as ast_id',
-          'house_ast.house_id',
-        );
-      const checkList = await db('list')
-        .where({ 'list.house_id': e.id })
-        .leftJoin('items', { 'list.id': 'items.list_id' })
-        .count('items.task');
-      return { ...e, openAst, checkList };
-    });
+    .whereIn('house.manager', manager);
+  if (astId) {
+    query
+      .leftJoin('house_ast', { 'house.id': 'house_ast.house_id' })
+      .where({ 'house_ast.ast_id': astId });
+  }
+
+  return query.map(async (e: any) => {
+    const openAst = await db('house_ast')
+      .where({ 'house_ast.house_id': e.id })
+      .leftJoin('assistant', { 'house_ast.ast_id': 'assistant.id' })
+      .leftJoin('user', { 'assistant.user_id': 'user.id' })
+      .select('user.full_name', 'assistant.id as ast_id', 'house_ast.house_id');
+    const checkList = await db('list')
+      .where({ 'list.house_id': e.id })
+      .leftJoin('items', { 'list.id': 'items.list_id' })
+      .count('items.task');
+    return { ...e, openAst, checkList };
+  });
 };
 
 // TODO: Combine with original findHouses by gating where clause

--- a/backend/src/models/stays/stays.ts
+++ b/backend/src/models/stays/stays.ts
@@ -71,15 +71,22 @@ export function findStaySummaryStandardized(stayId: number): QueryBuilder {
 export async function findAllStays(
   id: number[],
   filter?: 'all' | 'upcoming' | 'incomplete' | 'complete',
+  astId?: number,
 ): Promise<any> {
   const filterValue = filter || 'all';
 
   try {
     // Find all house ids related to properties manager owns
-    const houses = await db('house')
-      .select('id')
-      .whereIn('house.manager', id)
-      .map((val: any) => val.id);
+    const qHouse: QueryBuilder = db('house')
+      .select('house.id')
+      .leftJoin('house_ast', { 'house.id': 'house_ast.house_id' })
+      // .where({ 'house_ast.ast_id': 10 })
+      .whereIn('house.manager', id);
+
+    if (astId) {
+      qHouse.where({ 'house_ast.ast_id': astId });
+    }
+    const houses = await qHouse.map((val: any) => val.id);
 
     // Find all stays related to all found houses
     const query: QueryBuilder = db('stay')

--- a/backend/src/models/stays/stays.ts
+++ b/backend/src/models/stays/stays.ts
@@ -79,13 +79,16 @@ export async function findAllStays(
     // Find all house ids related to properties manager owns
     const qHouse: QueryBuilder = db('house')
       .select('house.id')
-      .leftJoin('house_ast', { 'house.id': 'house_ast.house_id' })
-      // .where({ 'house_ast.ast_id': 10 })
       .whereIn('house.manager', id);
 
+    // if getting stays for an ast, we need to only show houses
+    // where the ast is linked on house_ast table
     if (astId) {
-      qHouse.where({ 'house_ast.ast_id': astId });
+      qHouse
+        .leftJoin('house_ast', { 'house.id': 'house_ast.house_id' })
+        .where({ 'house_ast.ast_id': astId });
     }
+    // this is going to return an array of house ids
     const houses = await qHouse.map((val: any) => val.id);
 
     // Find all stays related to all found houses


### PR DESCRIPTION
# Description

Changed filters on house and stay getAll models.  Now an ast will only see properties and guests that a manager has assigned them. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Change status

- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
